### PR TITLE
[#10] 차량 상세 페이지 구현

### DIFF
--- a/src/components/feature/DetailForm/index.tsx
+++ b/src/components/feature/DetailForm/index.tsx
@@ -1,15 +1,29 @@
-import React from 'react';
+import { Car } from '@src/types/car';
 import * as S from './styled';
+import FormHeader from '../FormHeader';
+import FormBody from '../FormBody';
 
-const DetailForm = ({}) => {
-	const info = '차량 정보';
+const DetailForm = ({ car }: { car: Car }) => {
 	return (
 		<S.Container>
-			<p className="header">{info}</p>
-			<div className="body">
-				<span className="bold">대인</span>
-				<span>무한</span>
-			</div>
+			<FormHeader headerName={'차량정보'} />
+			<FormBody name={'차종'} description={car.attribute.segment} />
+			<FormBody name={'연료'} description={car.attribute.fuelType} />
+			<FormBody name={'이용가능일'} description={`${car.startDate}부터`} />
+
+			{car.insurance && (
+				<>
+					<FormHeader headerName={'보험'} />
+					<FormBody name={'대인'} description={car.insurance[0].description} />
+					<FormBody name={'대물'} description={car.insurance[1].description} />
+				</>
+			)}
+			{car.addtionalProduct && (
+				<>
+					<FormHeader headerName={'추가상품'} />
+					<FormBody name={'대물'} description={`월 ${car.addtionalProduct[0].amount} 원`} />
+				</>
+			)}
 		</S.Container>
 	);
 };

--- a/src/components/feature/DetailForm/styled.ts
+++ b/src/components/feature/DetailForm/styled.ts
@@ -1,26 +1,3 @@
 import styled from 'styled-components';
 
-export const Container = styled.section`
-	.header {
-		padding: 0 20px;
-		background-color: ${({ theme }) => theme.colors.primary};
-		color: ${({ theme }) => theme.colors.white};
-		font-size: ${({ theme }) => theme.fontSizes.medium};
-		font-weight: ${({ theme }) => theme.fontWeights.bold};
-		height: 48px;
-		display: flex;
-		align-items: center;
-	}
-	.body {
-		padding: 0 20px;
-		font-size: ${({ theme }) => theme.fontSizes.medium};
-		font-weight: ${({ theme }) => theme.fontWeights.normal};
-		height: 48px;
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-	}
-	.bold {
-		font-weight: ${({ theme }) => theme.fontWeights.bold};
-	}
-`;
+export const Container = styled.section``;

--- a/src/components/feature/FormBody/index.tsx
+++ b/src/components/feature/FormBody/index.tsx
@@ -1,0 +1,17 @@
+import { FormBodyWrap } from './styled';
+
+type Props = {
+	name: string;
+	description: string;
+};
+
+const FormBody = ({ name, description }: Props) => {
+	return (
+		<FormBodyWrap className="body">
+			<span className="bold">{name}</span>
+			<span>{description}</span>
+		</FormBodyWrap>
+	);
+};
+
+export default FormBody;

--- a/src/components/feature/FormBody/styled.ts
+++ b/src/components/feature/FormBody/styled.ts
@@ -1,0 +1,14 @@
+import styled from 'styled-components';
+
+export const FormBodyWrap = styled.div`
+	padding: 0 20px;
+	font-size: ${({ theme }) => theme.fontSizes.medium};
+	font-weight: ${({ theme }) => theme.fontWeights.normal};
+	height: 48px;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	.bold {
+		font-weight: ${({ theme }) => theme.fontWeights.bold};
+	}
+`;

--- a/src/components/feature/FormHeader/index.tsx
+++ b/src/components/feature/FormHeader/index.tsx
@@ -1,0 +1,10 @@
+import { FormHead } from './styled';
+
+type Props = {
+	headerName: string;
+};
+
+const FormHeader = ({ headerName }: Props) => {
+	return <FormHead className="header">{headerName}</FormHead>;
+};
+export default FormHeader;

--- a/src/components/feature/FormHeader/styled.ts
+++ b/src/components/feature/FormHeader/styled.ts
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+export const FormHead = styled.p`
+	padding: 0 20px;
+	background-color: ${({ theme }) => theme.colors.primary};
+	color: ${({ theme }) => theme.colors.white};
+	font-size: ${({ theme }) => theme.fontSizes.medium};
+	font-weight: ${({ theme }) => theme.fontWeights.bold};
+	height: 48px;
+	display: flex;
+	align-items: center;
+`;

--- a/src/hooks/useCar.ts
+++ b/src/hooks/useCar.ts
@@ -1,0 +1,24 @@
+import { getCars } from '@src/apis/car';
+import { useQuery } from '@tanstack/react-query';
+import { Car } from '@src/types/car';
+
+const useCar = (id: string) => {
+	const {
+		data: cars,
+		isLoading,
+		isError,
+	} = useQuery<Car[]>(['getCar'], () => getCars(''), {
+		refetchOnWindowFocus: false,
+	});
+
+	//FIXME: 필터조건으로 params로 받아온 id를 넘기면 될듯하다
+
+	const getCarById = (id: string) => {
+		const car = cars?.filter((car) => String(car.id) === id)[0] as Car;
+		return car;
+	};
+
+	return { car: getCarById(id), isLoading, isError };
+};
+
+export default useCar;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,16 +2,28 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
 import App from './App';
 import { GlobalStyle, theme } from './styles';
+
+const queryClient = new QueryClient({
+	defaultOptions: {
+		queries: {
+			retry: 1,
+			useErrorBoundary: true,
+		},
+	},
+});
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
 	<React.StrictMode>
 		<BrowserRouter>
-			<ThemeProvider theme={theme}>
-				<GlobalStyle />
-				<App />
-			</ThemeProvider>
+			<QueryClientProvider client={queryClient}>
+				<ThemeProvider theme={theme}>
+					<GlobalStyle />
+					<App />
+				</ThemeProvider>
+			</QueryClientProvider>
 		</BrowserRouter>
 	</React.StrictMode>,
 );

--- a/src/pages/CarDetail/index.tsx
+++ b/src/pages/CarDetail/index.tsx
@@ -1,18 +1,28 @@
 import * as S from './styled';
 import Image from '../../components/shared/Image';
+import useCar from '@src/hooks/useCar';
+import { DetailForm } from '@src/components';
+import { useParams } from 'react-router-dom';
 
 const CarDetail = () => {
-	const imgUrl: string = `https://blog.kakaocdn.net/dn/cFpDPS/btrmhg2fPGD/bNvrWQKWTuLzDmA0PcID8k/img.png`;
+	const { id } = useParams<{ id: string }>();
+	const { car } = useCar(id as string);
+
 	return (
 		<S.CarDetailWrap>
-			<S.ImgWrap>
-				<Image imgUrl={imgUrl} />
-			</S.ImgWrap>
-			<S.CarDetailTitle>
-				<S.BrandName>brand</S.BrandName>
-				<S.ModelName>name</S.ModelName>
-				<S.MonthPrice>월 amount 원</S.MonthPrice>
-			</S.CarDetailTitle>
+			{car && (
+				<>
+					<S.ImgWrap>
+						<Image imgUrl={car.attribute.imageUrl} />
+					</S.ImgWrap>
+					<S.CarDetailTitle>
+						<S.BrandName>{car.attribute.brand}</S.BrandName>
+						<S.ModelName>{car.attribute.name}</S.ModelName>
+						<S.MonthPrice>월 {car.amount} 원</S.MonthPrice>
+					</S.CarDetailTitle>
+					<DetailForm car={car} />
+				</>
+			)}
 		</S.CarDetailWrap>
 	);
 };

--- a/src/types/car.ts
+++ b/src/types/car.ts
@@ -15,7 +15,7 @@ export type Attribute = {
 	brand: string;
 	name: string;
 	segment: Segment;
-	fuel: Fuel;
+	fuelType: Fuel;
 	imageUrl: string;
 };
 


### PR DESCRIPTION
## 해결한 이슈

- #10 

<br />

## 해결 방법

- 헤더
 - React-Query를 이용해 패칭받은 데이터를 params를 통해 전달받은 id 값으로 필터링해 기존의 전체 데이터에서 id 에 해당하는 디테일페이지 데이터를 사용해 페이지 렌더링
 - 상세내용에 사용되는 헤더부분과 바디부분을 분리하고, 이를 재사용 가능한 컴포넌트로 만들어, 재사용하여 구현

<br />

## 캡처 첨부

<img width="472" alt="스크린샷 2022-11-03 오전 5 23 19" src="https://user-images.githubusercontent.com/108744804/199595062-fb0d12fd-90e3-4a1b-a03c-f129e479d6ae.png">

<br />

## 추가적인 태스크

- 보험과 추가상품은 map 함수를 통해 추가되는 내역들 렌더링할 수 있게 변경하기
- 헤더를 제외한 부분만 스크롤 생기게 구현하기

<br />
<br />

## PR Submit 이전에 확인하세요 !

`체크리스트`

- [x] Merge 하는 브랜치에 Master/Main 브랜치가 아닙니다.
