### PR TITLE
[#10] 차량 상세페이지 컴포넌트 수정

### DIFF
--- a/src/components/feature/DetailForm/index.tsx
+++ b/src/components/feature/DetailForm/index.tsx
@@ -1,27 +1,36 @@
+import { useMemo } from 'react';
 import { Car } from '@src/types/car';
 import * as S from './styled';
 import FormHeader from '../FormHeader';
 import FormBody from '../FormBody';
+import { getDay } from '@src/utils/DateUtils';
+import { carAttributeTable } from '@src/constants/car';
+import { numberWithCommasConverter } from '@src/utils/StringUtils';
 
 const DetailForm = ({ car }: { car: Car }) => {
+	const day = useMemo(() => getDay(car.startDate), []);
+
 	return (
 		<S.Container>
 			<FormHeader headerName={'차량정보'} />
-			<FormBody name={'차종'} description={car.attribute.segment} />
-			<FormBody name={'연료'} description={car.attribute.fuelType} />
-			<FormBody name={'이용가능일'} description={`${car.startDate}부터`} />
+			<FormBody name={'차종'} description={carAttributeTable.segmentTable[car.attribute.segment]} />
+			<FormBody name={'연료'} description={carAttributeTable.fuelTable[car.attribute.fuelType]} />
+			<FormBody name={'이용가능일'} description={`${day}부터`} />
 
 			{car.insurance && (
 				<>
 					<FormHeader headerName={'보험'} />
-					<FormBody name={'대인'} description={car.insurance[0].description} />
-					<FormBody name={'대물'} description={car.insurance[1].description} />
+					{car.insurance.map((insure: { name: string; description: string }) => (
+						<FormBody key={insure.name} name={insure.name} description={insure.description} />
+					))}
 				</>
 			)}
-			{car.addtionalProduct && (
+			{car.additionalProducts && (
 				<>
 					<FormHeader headerName={'추가상품'} />
-					<FormBody name={'대물'} description={`월 ${car.addtionalProduct[0].amount} 원`} />
+					{car.additionalProducts.map((product: { name: string; amount: number }) => (
+						<FormBody key={product.name} name={product.name} description={`월 ${numberWithCommasConverter(product.amount)} 원`} />
+					))}
 				</>
 			)}
 		</S.Container>

--- a/src/components/feature/DetailForm/index.tsx
+++ b/src/components/feature/DetailForm/index.tsx
@@ -20,8 +20,8 @@ const DetailForm = ({ car }: { car: Car }) => {
 			{car.insurance && (
 				<>
 					<FormHeader headerName={'보험'} />
-					{car.insurance.map((insure: { name: string; description: string }) => (
-						<FormBody key={insure.name} name={insure.name} description={insure.description} />
+					{car.insurance.map((insurance: { name: string; description: string }) => (
+						<FormBody key={insurance.name} name={insurance.name} description={insurance.description} />
 					))}
 				</>
 			)}

--- a/src/hooks/useCar.ts
+++ b/src/hooks/useCar.ts
@@ -11,8 +11,6 @@ const useCar = (id: string) => {
 		refetchOnWindowFocus: false,
 	});
 
-	//FIXME: 필터조건으로 params로 받아온 id를 넘기면 될듯하다
-
 	const getCarById = (id: string) => {
 		const car = cars?.filter((car) => String(car.id) === id)[0] as Car;
 		return car;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,24 +16,15 @@ const queryClient = new QueryClient({
 	},
 });
 
-const queryClient = new QueryClient({
-	defaultOptions: {
-		queries: {
-			retry: 1,
-			useErrorBoundary: true,
-		},
-	},
-});
-
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
 	<React.StrictMode>
 		<BrowserRouter>
 			<QueryClientProvider client={queryClient}>
 				<ThemeProvider theme={theme}>
-				 <RecoilRoot>
-					<GlobalStyle />
-					<App />
-         </RecoilRoot>
+					<RecoilRoot>
+						<GlobalStyle />
+						<App />
+					</RecoilRoot>
 				</ThemeProvider>
 			</QueryClientProvider>
 		</BrowserRouter>

--- a/src/pages/CarDetail/index.tsx
+++ b/src/pages/CarDetail/index.tsx
@@ -1,8 +1,9 @@
+import { useParams } from 'react-router-dom';
 import * as S from './styled';
 import Image from '../../components/shared/Image';
 import useCar from '@src/hooks/useCar';
 import { DetailForm } from '@src/components';
-import { useParams } from 'react-router-dom';
+import { numberWithCommasConverter } from '@src/utils/StringUtils';
 
 const CarDetail = () => {
 	const { id } = useParams<{ id: string }>();
@@ -18,7 +19,7 @@ const CarDetail = () => {
 					<S.CarDetailTitle>
 						<S.BrandName>{car.attribute.brand}</S.BrandName>
 						<S.ModelName>{car.attribute.name}</S.ModelName>
-						<S.MonthPrice>월 {car.amount} 원</S.MonthPrice>
+						<S.MonthPrice>월 {numberWithCommasConverter(car.amount)} 원</S.MonthPrice>
 					</S.CarDetailTitle>
 					<DetailForm car={car} />
 				</>

--- a/src/pages/CarDetail/styled.ts
+++ b/src/pages/CarDetail/styled.ts
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
 
 export const CarDetailWrap = styled.div`
-	height: calc(100vh-5rem);
-	margin-top: 5rem;
+	height: calc(100vh-60px);
+	margin-top: 60px;
 `;
 
 export const ImgWrap = styled.div`

--- a/src/pages/CarDetail/styled.ts
+++ b/src/pages/CarDetail/styled.ts
@@ -1,7 +1,8 @@
 import styled from 'styled-components';
 
 export const CarDetailWrap = styled.div`
-	margin-top: 80px;
+	height: calc(100vh-5rem);
+	margin-top: 5rem;
 `;
 
 export const ImgWrap = styled.div`

--- a/src/pages/CarList/index.tsx
+++ b/src/pages/CarList/index.tsx
@@ -8,6 +8,8 @@ import useCars from '@src/hooks/useCars';
 
 const CarList = () => {
 	const { cars, isLoading, isEmtpy } = useCars();
+	const [segmentInfo, setSegmentInfo] = useRecoilState(SegmentAtom);
+	const [fuelTypeInfo, setFuelTypeInfo] = useRecoilState(fuelTypeAtom);
 
 	return (
 		<S.Container>

--- a/src/pages/CarList/styled.ts
+++ b/src/pages/CarList/styled.ts
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
 
 export const Container = styled.section`
-	height: calc(100vh-5rem);
-	margin-top: 5rem;
+	height: calc(100vh-60px);
+	margin-top: 60px;
 	.cheap {
 		font-weight: ${({ theme }) => theme.fontWeights.bold};
 		font-size: ${({ theme }) => theme.fontSizes.normal};

--- a/src/types/car.ts
+++ b/src/types/car.ts
@@ -6,7 +6,7 @@ export type Insurance = {
 	description: string;
 };
 
-export type AdditionalProduct = {
+export type AdditionalProducts = {
 	name: string;
 	amount: number;
 };
@@ -26,7 +26,7 @@ export type Car = {
 	startDate: string;
 	createdAt: string;
 	insurance?: Insurance[];
-	addtionalProduct?: AdditionalProduct[];
+	additionalProducts?: AdditionalProducts[];
 };
 
 export type CarsReponseDto = {

--- a/src/utils/DateUtils.ts
+++ b/src/utils/DateUtils.ts
@@ -3,3 +3,10 @@ const DAY1 = 1;
 
 export const isNewDate = (createdDateString: string) =>
 	(new Date().getTime() - new Date(createdDateString).getTime()) / MILLISECOND_TO_HOUR <= DAY1;
+
+export const getDay = (day: string) => {
+	const days = ['일', '월', '화', '수', '목', '금', '토'];
+	const date = new Date(day);
+
+	return `${date.getMonth()}월 ${date.getDay()}일 (${days[date.getDate()]})`;
+};


### PR DESCRIPTION
## 해결한 이슈

- #10 

<br />

## 해결 방법

`디테일 페이지 내 보험, 추가상품 내역`

+ 이전 구현사항에서 디테일 페이지의 보험, 추가상품 내역을 배열의 인덱스로 반환시키는 로직은 배열이 더 생겼을때 렌더링을 시켜주지 못하는 문제를 확인
+ map함수로 데이터의 name과 description를 사용해 보험, 추가상품 내역을 누락없이 렌더링.

```tsx
{car.insurance.map((insurance: { name: string; description: string }) => (
  <FormBody key={insurance.name} name={insurance.name} description={insurance.description} />
))}
```

`실제 렌더링할 UI 데이터 가공`

+ 서버로부터 받아오는 차량 정보 중, 이용가능일(car.startDate)의 형식을 yyyy-mm-ddT형식에서 mm월 dd일 (요일) 형식으로 변환

```tsx
export const getDay = (day: string) => {
	const days = ['일', '월', '화', '수', '목', '금', '토'];
	const date = new Date(day);

	return `${date.getMonth()}월 ${date.getDay()}일 (${days[date.getDate()]})`;
};
```

<br />

## 캡처 첨부

`차량 디테일 페이지 렌더링 결과`

<img width="306" alt="스크린샷 2022-11-03 오후 5 49 07" src="https://user-images.githubusercontent.com/108744804/199679616-a0a8cd13-abde-4102-8aaf-cd6095e1378f.png">

<br />

## 추가적인 태스크

+ 차량 상세 페이지 컨테이너의 전체 Height 를 조절(Header를 제외한 부분)

<br />

## PR Submit 이전에 확인하세요 !

`체크리스트`

- [x] Merge 하는 브랜치에 Master/Main 브랜치가 아닙니다.
