### PR TITLE
[#22] 차량 목록 조회 필터링 기능 추가 & 차량 목록 페이지 개선

### DIFF
--- a/src/components/feature/CarListItem/index.tsx
+++ b/src/components/feature/CarListItem/index.tsx
@@ -23,7 +23,7 @@ const CarListItem = ({ car }: { car: Car }) => {
 				</S.Information>
 				<S.Img>
 					<Image imgUrl={car.attribute.imageUrl} />
-					<p>{isNewDate(car.createdAt) && '신규'}</p>
+					<S.NewChip>{isNewDate(car.createdAt) && '신규'}</S.NewChip>
 				</S.Img>
 			</S.SLink>
 		</S.Container>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,7 @@
 // Shared Components
 export { default as Image } from '@src/components/shared/Image';
+export { default as StatusContent } from '@src/components/shared/StatusContent';
+export { default as SEOMetaTag } from '@src/components/shared/SEOMetaTag';
 
 // Layout Components
 export { default as Layout } from '@src/components/layout';

--- a/src/components/shared/StatusContent/index.tsx
+++ b/src/components/shared/StatusContent/index.tsx
@@ -1,0 +1,8 @@
+import { PropsWithChildren } from 'react';
+import * as S from './styled';
+
+const StatusContent = (props: PropsWithChildren) => {
+	return <S.Container>{props.children}</S.Container>;
+};
+
+export default StatusContent;

--- a/src/components/shared/StatusContent/styled.ts
+++ b/src/components/shared/StatusContent/styled.ts
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+	flex: 1;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-weight: ${({ theme }) => theme.fontWeights.bold};
+	font-size: ${({ theme }) => theme.fontSizes.medium};
+`;

--- a/src/pages/CarList/index.tsx
+++ b/src/pages/CarList/index.tsx
@@ -1,10 +1,9 @@
-import * as S from './styled';
-import Nav from '../../components/feature/Nav';
-import { segmentDummyData, fuelTypeDummyData } from '@src/constants/attributeDummyData';
 import { useRecoilState } from 'recoil';
-import { SegmentAtom, fuelTypeAtom } from '../../recoil/atoms/ChipAtom';
-import { CarListItem } from '@src/components';
+import * as S from './styled';
+import { CarListItem, StatusContent, Nav } from '@src/components';
+import { SegmentAtom, fuelTypeAtom } from '@src/recoil/atoms/ChipAtom';
 import useCars from '@src/hooks/useCars';
+import { segmentDummyData, fuelTypeDummyData } from '@src/constants/attributeDummyData';
 
 const CarList = () => {
 	const { cars, isLoading, isEmtpy } = useCars();
@@ -15,8 +14,11 @@ const CarList = () => {
 		<S.Container>
 			<Nav dummy={segmentDummyData} state={segmentInfo} setState={setSegmentInfo} />
 			<Nav dummy={fuelTypeDummyData} state={fuelTypeInfo} setState={setFuelTypeInfo} />
-			{isLoading && <S.Message>불러오는 중</S.Message>}
-			{isEmtpy ? <S.Message>차량이 없습니다.</S.Message> : cars?.map((car) => <CarListItem key={car.id} car={car} />)}
+			<S.CarListScrollInnerWrapper>
+				{isLoading && <StatusContent>불러오는 중</StatusContent>}
+				{isEmtpy && <StatusContent>차량이 없습니다.</StatusContent>}
+				{!isEmtpy && cars?.map((car) => <CarListItem key={car.id} car={car} />)}
+			</S.CarListScrollInnerWrapper>
 		</S.Container>
 	);
 };

--- a/src/pages/CarList/styled.ts
+++ b/src/pages/CarList/styled.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
-export const Container = styled.section`
+export const Container = styled.div`
+	position: relative;
 	height: calc(100vh-60px);
 	margin-top: 60px;
 	.cheap {
@@ -28,11 +29,10 @@ export const Container = styled.section`
 	}
 `;
 
-export const Message = styled.div`
-	font-weight: ${({ theme }) => theme.fontWeights.bold};
-	font-size: ${({ theme }) => theme.fontSizes.medium};
-
+export const CarListScrollInnerWrapper = styled.ul`
 	display: flex;
-	justify-content: center;
-	align-items: center;
+	flex-direction: column;
+	min-height: calc(100vh - 138px);
+	max-height: calc(100vh - 138px);
+	overflow-y: scroll;
 `;

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -1,5 +1,6 @@
 import * as styled from 'styled-components';
 import reset from 'styled-reset';
+import { size } from './theme';
 
 const GlobalStyle = styled.createGlobalStyle`
 	${reset};
@@ -11,6 +12,8 @@ const GlobalStyle = styled.createGlobalStyle`
 	}
 
 	body {
+		max-width: '${size.mobile}px';
+		margin: 0 auto;
 		font-size: 16px;
 	}
 

--- a/src/styles/styled.d.ts
+++ b/src/styles/styled.d.ts
@@ -2,6 +2,7 @@ import 'styled-components';
 
 declare module 'styled-components' {
 	export interface DefaultTheme {
+		minWidth: string;
 		maxWidth: string;
 		fontSizes: {
 			small: string;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -4,11 +4,11 @@ const pixelToRem = (size: number) => `${size / 16}rem`;
 
 export const size = {
 	mobile: 450,
-	desktop: 1280,
 };
 
 const theme: DefaultTheme = {
-	maxWidth: pixelToRem(size.desktop),
+	minWidth: pixelToRem(360),
+	maxWidth: pixelToRem(size.mobile),
 	fontSizes: {
 		small: pixelToRem(12),
 		normal: pixelToRem(14),


### PR DESCRIPTION
## 해결한 이슈

#22 

<br />

## 해결 방법

### `차량 리스트 컨테이너 영역만 스크롤 컨테이너 적용`

- 차량 리스트 컨테이너 영역을 `전체 페이지 뷰 height - Header 와 차량 필터링 세션을 제외한 height 만큼` 전체 높이로 설정

<img width="351" alt="image" src="https://user-images.githubusercontent.com/50790145/199735496-88a25669-1e0d-43e4-a7b4-8a7facbe509d.png">

### `검색 차량 데이터 존재 X, 데이터 로딩 중 UI 컴포넌트 분리`

- `StatusContent` 컴포넌트로 분리, 현재 요구사항 UI 에는 간단한 텍스트로만 표현되지만 이후 요구사항이 변경되어 더 복잡한 UI 가 필요할 것을 고려해서 props 로 받을 데이터를 특정 텍스트 데이터가 아닌 `PropsWidthChildren` 으로 타입이 `ReactNode` 가 들어올수 있게 구현

### `차량 필터링 데이터 조회`

+ 구현 후 작성 예정 


<br />

## 캡처 첨부

### `차량 목록 컨테이너만 스크롤 컨테이너로 적용 전후`

`적용전`

![car_list_before_refactor](https://user-images.githubusercontent.com/50790145/199736726-fcb9478c-3f49-44a6-9368-d480349f8c0d.gif)


`적용후`

![car_list_after_refactor](https://user-images.githubusercontent.com/50790145/199736767-207aecab-edcf-4bfd-83e0-3496ac9a4a77.gif)


### `차량 데이터 로드 중, 빈 데이터일 경우 보여줄 StatusContent 컴포넌트 분리후 각 상황에 따른 UI 결과 예시`

`빈 차량 데이터일 경우`

<img width="295" alt="car_list_empty_case" src="https://user-images.githubusercontent.com/50790145/199737098-63208b11-d143-47aa-b45e-970c949ebea2.png">


`차량 데이터 로드 중일 경우`

<img width="296" alt="car_list_loading_case" src="https://user-images.githubusercontent.com/50790145/199737128-374bc584-d681-44d8-99c0-f19c6b05c4bf.png">


<br />

## 추가적인 태스크

- 내용을 입력해주세요.

<br />
<br />

## PR Submit 이전에 확인하세요 !

`체크리스트`

- [x] Merge 하는 브랜치에 Master/Main 브랜치가 아닙니다.
