### PR TITLE
Feature/jonghyeon

### DIFF
--- a/src/components/skeleton/SkeletonCarList/SkeletonCarListItem/Index.tsx
+++ b/src/components/skeleton/SkeletonCarList/SkeletonCarListItem/Index.tsx
@@ -1,0 +1,27 @@
+import SkeletonElement from '../../SkeletonElement';
+import { SkeletonContainer } from './styled';
+
+const SkeletonCarListItem = () => {
+	return (
+		<SkeletonContainer>
+			<div className="skelItemDiv">
+				<div className="skeletonInfoDiv">
+					<div className="skeletonBrandDiv">
+						<SkeletonElement type="brand" />
+						<SkeletonElement type="name" />
+					</div>
+					<div className="skeletonSegmentDiv">
+						<SkeletonElement type="segment" />
+						<SkeletonElement type="amount" />
+					</div>
+				</div>
+				<div className="skeletonImgDiv">
+					<SkeletonElement type="img" />
+					<SkeletonElement type="newchip" />
+				</div>
+			</div>
+		</SkeletonContainer>
+	);
+};
+
+export default SkeletonCarListItem;

--- a/src/components/skeleton/SkeletonCarList/SkeletonCarListItem/styled.ts
+++ b/src/components/skeleton/SkeletonCarList/SkeletonCarListItem/styled.ts
@@ -1,0 +1,84 @@
+import styled from 'styled-components';
+
+export const SkeletonContainer = styled.div`
+	--elwidth: 97px;
+	--elheight: 18px;
+	list-style: none;
+
+	.skeleton {
+		background: #ddd;
+	}
+	.skelItemDiv {
+		display: flex;
+		flex-direction: row;
+		width: 100%;
+		padding: 1.2rem;
+		border-bottom: 1px solid black;
+		justify-content: space-between;
+		height: 7.5rem;
+		text-decoration: none;
+
+		.skeletonInfoDiv {
+			display: flex;
+			flex-direction: column;
+			justify-content: space-between;
+			line-height: 1.05rem;
+
+			.skeletonBrandDiv {
+				display: flex;
+				flex-direction: column;
+
+				.skeleton.brand {
+					width: var(--elwidth);
+					height: var(--elheight);
+					background-color: #ddd;
+				}
+
+				.skeleton.name {
+					width: var(--elwidth);
+					height: var(--elheight);
+				}
+			}
+
+			.skeletonSegmentDiv {
+				display: flex;
+				flex-direction: column;
+
+				.skeleton.segment {
+					width: var(--elwidth);
+					height: var(--elheight);
+				}
+
+				.skeleton.amount {
+					width: var(--elwidth);
+					height: var(--elheight);
+				}
+			}
+		}
+		.skeletonImgDiv {
+			display: flex;
+			position: relative;
+
+			.skeleton.img {
+				position: absolute;
+				width: 152px;
+				height: 80px;
+				right: 0;
+				z-index: -1;
+			}
+
+			.skeleton.newchip {
+				display: flex;
+				position: absolute;
+				justify-content: center;
+				align-items: center;
+				right: 0;
+				top: -0.5rem;
+				width: 52px;
+				height: 22px;
+				border-radius: 42px;
+				background-color: #808080;
+			}
+		}
+	}
+`;

--- a/src/components/skeleton/SkeletonCarList/index.tsx
+++ b/src/components/skeleton/SkeletonCarList/index.tsx
@@ -1,0 +1,16 @@
+import SkeletonCarListItem from './SkeletonCarListItem/Index';
+
+const SkeletonCarList = () => {
+	return (
+		<>
+			<SkeletonCarListItem />
+			<SkeletonCarListItem />
+			<SkeletonCarListItem />
+			<SkeletonCarListItem />
+			<SkeletonCarListItem />
+			<SkeletonCarListItem />
+		</>
+	);
+};
+
+export default SkeletonCarList;

--- a/src/components/skeleton/SkeletonElement/index.tsx
+++ b/src/components/skeleton/SkeletonElement/index.tsx
@@ -1,0 +1,16 @@
+import { Shimmer } from './styled';
+
+type Props = {
+	type: string;
+};
+
+const SkeletonElement = ({ type }: Props) => {
+	const classes = `skeleton ${type}`;
+	return (
+		<div className={classes}>
+			<Shimmer />
+		</div>
+	);
+};
+
+export default SkeletonElement;

--- a/src/components/skeleton/SkeletonElement/styled.ts
+++ b/src/components/skeleton/SkeletonElement/styled.ts
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+
+export const Shimmer = styled.div`
+	width: 50%;
+	height: 100%;
+	background-color: rgba(255, 255, 255, 0.2);
+	box-shadow: 0 0 30px 30px rgba(255, 255, 255, 0.05);
+	animation: loading 2s infinite;
+	@keyframes loading {
+		0% {
+			transform: translateX(-150%);
+		}
+		50% {
+			transform: translateX(-60%);
+		}
+		100% {
+			transform: translate(150%);
+		}
+	}
+`;

--- a/src/hooks/useCars.ts
+++ b/src/hooks/useCars.ts
@@ -3,11 +3,11 @@ import { getCars } from '@src/apis/car';
 import { Car } from '@src/types/car';
 
 const useCars = (queyString: string = '') => {
-	const { data: cars, isLoading, isError } = useQuery<Car[]>(['getCars', queyString], () => getCars(queyString));
+	const { data: cars, isLoading, isError, isFetching } = useQuery<Car[]>(['getCars', queyString], () => getCars(queyString));
 
 	const isEmptyCars = (cars: Car[] | undefined) => !cars || cars.length === 0;
 
-	return { cars, isLoading, isError, isEmtpy: isEmptyCars(cars) };
+	return { cars, isLoading, isError, isFetching, isEmtpy: isEmptyCars(cars) };
 };
 
 export default useCars;

--- a/src/pages/CarList/index.tsx
+++ b/src/pages/CarList/index.tsx
@@ -5,11 +5,12 @@ import { SegmentAtom, fuelTypeAtom } from '@src/recoil/atoms/ChipAtom';
 import useCars from '@src/hooks/useCars';
 import { segmentDummyData, fuelTypeDummyData } from '@src/constants/attributeDummyData';
 import { queryStringGenerator } from '@src/utils/StringUtils';
+import SkeletonCarList from '@src/components/skeleton/SkeletonCarList';
 
 const CarList = () => {
 	const [segmentInfo, setSegmentInfo] = useRecoilState(SegmentAtom);
 	const [fuelTypeInfo, setFuelTypeInfo] = useRecoilState(fuelTypeAtom);
-	const { cars, isLoading, isEmtpy } = useCars(
+	const { cars, isLoading, isEmtpy, isFetching } = useCars(
 		queryStringGenerator({ fuelType: fuelTypeInfo.value, segment: segmentInfo.value }, ['ALL-fuel', 'ALL-segment']),
 	);
 
@@ -18,7 +19,7 @@ const CarList = () => {
 			<Nav dummy={segmentDummyData} state={segmentInfo} setState={setSegmentInfo} />
 			<Nav dummy={fuelTypeDummyData} state={fuelTypeInfo} setState={setFuelTypeInfo} />
 			<S.CarListScrollInnerWrapper>
-				{isLoading && <StatusContent>불러오는 중</StatusContent>}
+				{isFetching && <SkeletonCarList />}
 				{!isLoading && isEmtpy && <StatusContent>차량이 없습니다.</StatusContent>}
 				{!isEmtpy && cars?.map((car) => <CarListItem key={car.id} car={car} />)}
 			</S.CarListScrollInnerWrapper>


### PR DESCRIPTION
## 해결한 이슈

- #34 

<br />

## 해결 방법

`UX 개선을 위한 Skeleton UI 추가` 

+ 차량 리스트 페이지에서 데이터가 많아진다면, 렌더링 시간이 증가할 것으로 예상.
+ 스피너로도 렌더링 시간동안 유저에게 렌더링 시도하는 상태임을 알려줄 수 있지만, 실제 렌더링되는 페이지와 비슷한 형태의 Skeleton UI 가 있다면 UX 개선에 도움이 될 것으로 판단
  + 전달받은 type props를 통해 className을 정의해주고 이를 기반으로 스타일 작업을 해 skeleton div를 재사용 가능하게 구현

```tsx
type Props = {
	type: string;
};

const SkeletonElement = ({ type }: Props) => {
	const classes = `skeleton ${type}`;
	return (
		<div className={classes}>
			<Shimmer />
		</div>
	);
};

```

<br />

## 캡처 첨부

`skeleton ui가 적용된 차량상세페이지의 컨텐츠 부분`

<img width="454" alt="스크린샷 2022-11-04 오후 10 10 33" src="https://user-images.githubusercontent.com/108744804/199980342-6c61516f-1086-426c-bc26-22d1d72c6331.png">

<br />

## 추가적인 태스크

- 무한 스크롤이나, 페이지 크기가 늘어났을때 skeleton ui를 어떻게 적용할 것인지에 대한 고려가 필요할듯함.

<br />
<br />

## PR Submit 이전에 확인하세요 !

`체크리스트`

- [x] Merge 하는 브랜치에 Master/Main 브랜치가 아닙니다.
